### PR TITLE
beschreibung der score-berechnung verbessert [fixes #9]

### DIFF
--- a/src/app/quiz/quiz.component.ts
+++ b/src/app/quiz/quiz.component.ts
@@ -457,8 +457,8 @@ export class QuizComponent implements OnInit, AfterContentInit, AfterViewInit, A
 		let description = "";
 		if (answer === 'enthaltung') { // Enthaltung
 			punkte = partyResults[opt[0]] + 0.5 * partyResults[opt[1]] + 0.5 * partyResults[opt[2]];
-			description = "(Enthaltung + 1/2 · Ja + 1/2 · Nein) / Gesamt = ("
-				+ partyResults[opt[0]] + " + " + 0.5 * partyResults[opt[1]] + " + " + 0.5 * partyResults[opt[2]] + ") / " + nAbgegebeneStimmen
+			description = "(1/2 · Ja + 1/2 · Nein + Enthaltung) / Gesamt = ("
+				+ 0.5 * partyResults[opt[1]] + " + " + 0.5 * partyResults[opt[2]] + " + " + partyResults[opt[0]] + ") / " + nAbgegebeneStimmen
 				+ " = " + this.toPercent (punkte / nAbgegebeneStimmen);
 		} else if (answer === 'ja') { // ja
 			punkte = 0.5 * partyResults[opt[0]] + partyResults[opt[1]];


### PR DESCRIPTION
reihenfolge ist jetzt nicht mehr

    (Enthaltung + 1/2 · Ja + 1/2 · Nein) / Gesamt

sondern

    (1/2 · Ja + 1/2 · Nein + Enthaltung) / Gesamt

wenn enthalten wurde. reihenfolge also wie bei der balkenanzeige.