### PR TITLE
FAZ-Kritik eingearbeitet

### DIFF
--- a/src/assets/votes.json
+++ b/src/assets/votes.json
@@ -109,7 +109,7 @@
             "subtext": "",
             "fragen": {
                 "018-241-01": {
-                    "context": "Immer mehr neue Arbeitsverträge sind nur befristet. ",
+                    "context": "Viele neue Arbeitsverträge sind nur befristet. ",
                     "frage": "Sollten sachgrundlose Befristungen abgeschafft werden? ",
                     "short": "sachgrundlose Befristung abschaffen",
                     "subtext": "",
@@ -915,7 +915,7 @@
                     "invert": true
                 },
                 "018-190-04": {
-                    "context": "Internationale Abkommen vereinfachen den Handelsverkehr. Der Inhalt des geplanten Kanada-EU-Freihandelabkommens ist geheim.",
+                    "context": "Internationale Abkommen vereinfachen den Handelsverkehr.",
                     "frage": "Sollte CETA weiterverfolgt werden?",
                     "short": "CETA weitermachen",
                     "subtext": "",


### PR DESCRIPTION
die FAZ hat sich ausfuehrlich auch inhaltlich mit deinem wal auseinander gesetzt! wow :)
http://www.faz.net/aktuell/wirtschaft/alternative-zum-wahl-o-mat-abgeordnete-im-realitaetscheck-15172182.html

ceta ist wirklich seit 2014 oeffentlich...