### PR TITLE
Hauptseiten Update nach der Bundestagswahl 2017

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -20,7 +20,7 @@
   			welche Parteien in deinem Sinne abgestimmt haben.
   		</p>
   		<p>
-  			<a routerLink="/quiz/{{getQuestionIndex ()}}" class="w3-button w3-indigo w3-hover-blue">Hier gehts zum Quiz</a>
+  			<a routerLink="/quiz/{{getQuestionIndex ()}}" class="w3-button w3-indigo w3-hover-blue">Quiz zur Bundestagswahl 2017</a>
   		</p>
   		<p>
 			Auch wenn dein Wal dem <a href="https://www.wahl-o-mat.de/" target="_blank">Wahl-O-Mat</a> sehr ähnelt, steckt doch ein ganz anderes Konzept dahinter.
@@ -28,5 +28,12 @@
 			&mdash; hier zählt, wie sie zu einem Thema <em>abgestimmt haben!</em>
 			Das unterscheidet deinen Wal übrigens auch von den typischen Wahlprogrammen.
   		</p>
+    <p> <i>Update:</i> </p>
+    <p>
+      Die Bundestagswahl 2017 ist nun schon vorüber.
+      Trotzdem könnt ihr das Quiz zur Bundestagswahl 2017 mit den Abstimmungsergebnissen von Abstimmungen zwischen 2013 und 2017 weiterhin spielen.
+      Ob es für eine zukünftige Wahlen wieder ein DeinWal.de Quiz geben wird ist noch offen,
+      aber aufgrund des enormen positiven Feedbacks haben wir Lust, DeinWal auch in Zukunft weiter zu führen.
+    </p>
 	</div>
 </div>


### PR DESCRIPTION
Erklärtext hinzugefügt:

      Die Bundestagswahl 2017 ist nun schon vorüber.
      Trotzdem könnt ihr das Quiz zur Bundestagswahl 2017 mit den Abstimmungsergebnissen von Abstimmungen zwischen 2013 und 2017 weiterhin spielen.
      Ob es für eine zukünftige Wahlen wieder ein DeinWal.de Quiz geben wird ist noch offen,
      aber aufgrund des enormen positiven Feedbacks haben wir Lust, DeinWal auch in Zukunft weiter zu führen.